### PR TITLE
Added button to scale the image

### DIFF
--- a/components/AssetView.vue
+++ b/components/AssetView.vue
@@ -44,6 +44,11 @@ img.zoomed {
                        @click.prevent="downloadFile"
                        prepend-icon="mdi-download">Download File
                 </v-btn>
+                <v-btn
+                    variant="outlined" size="small" color="secondary" class="mx-1"
+                    @click="sizeModalOpen = true"
+                    prepend-icon="mdi-image-size-select-large">Other size
+                </v-btn>
             </v-col>
         </v-row>
         <v-row>
@@ -75,6 +80,11 @@ img.zoomed {
                 </div>
             </v-col>
         </v-row>
+
+        <SizeSelectionModal
+            v-model="sizeModalOpen"
+            @select="handleSizeSelection"
+        />
     </v-col>
 </template>
 <script setup lang="ts">
@@ -84,6 +94,7 @@ import type { VersionManifest } from "~/types";
 import BackBtn from "~/components/BackBtn.vue";
 // import BlobAsText from "~/components/BlobAsText.vue";
 import TextContent from "~/components/TextContent.vue";
+import SizeSelectionModal from "~/components/SizeSelectionModal.vue";
 
 const props = defineProps<{
     version: string,
@@ -381,6 +392,69 @@ const downloadFile = async () => {
     URL.revokeObjectURL(url);
 };
 
+const resizeImageToTargetSize = (img, targetSize) => {
+    return new Promise((resolve) => {
+        const canvas = document.createElement('canvas');
+        const ctx = canvas.getContext('2d');
+        const maxDimension = Math.max(img.width, img.height);
+        const minDimension = Math.min(img.width, img.height);
+
+        let scale = targetSize / maxDimension;
+        const scaledMax = maxDimension * scale;
+        const scaledMin = minDimension * scale;
+
+        if (scaledMax > 1024) {
+            scale = 1024 / maxDimension;
+        }
+
+        const finalWidth = Math.round(img.width * scale);
+        const finalHeight = Math.round(img.height * scale);
+
+        canvas.width = finalWidth;
+        canvas.height = finalHeight;
+
+        ctx.imageSmoothingEnabled = false;
+        ctx.webkitImageSmoothingEnabled = false;
+        ctx.mozImageSmoothingEnabled = false;
+        ctx.drawImage(img, 0, 0, finalWidth, finalHeight);
+
+        resolve(canvas);
+    });
+};
+
+const downloadResizedImage = async (targetSize: number) => {
+    if (assetContentStatus.value !== 'success') {
+        await assetContentExecute();
+    }
+
+    try {
+        const imgUrl = URL.createObjectURL(assetContent.value);
+        const img = new Image();
+
+        img.onload = async () => {
+            const resizedCanvas = await resizeImageToTargetSize(img, targetSize);
+
+            resizedCanvas.toBlob((blob) => {
+                const url = URL.createObjectURL(blob);
+                const el = document.createElement('a');
+                el.href = url;
+                el.download = `resized_${targetSize}_${assetName.value}`;
+                document.body.appendChild(el);
+                el.click();
+                document.body.removeChild(el);
+                URL.revokeObjectURL(url);
+            }, 'image/png');
+
+            URL.revokeObjectURL(imgUrl);
+        };
+
+        img.src = imgUrl;
+    } catch (error) {
+        console.error('Resize failed:', error);
+        alert('Resize failed. Please try again.');
+    }
+}
+
 const isNotFound = computed(() => {
     if (!assetContentError.value) return false;
     return assetContentError.value.statusCode === 404;
@@ -389,5 +463,11 @@ const isNotFound = computed(() => {
 const zoomed = ref(true);
 const toggleZoom = () => {
     zoomed.value = !zoomed.value;
+};
+
+const sizeModalOpen = ref(false);
+
+const handleSizeSelection = async (size: number) => {
+    await downloadResizedImage(size);
 };
 </script>

--- a/components/AssetView.vue
+++ b/components/AssetView.vue
@@ -392,10 +392,10 @@ const downloadFile = async () => {
     URL.revokeObjectURL(url);
 };
 
-const resizeImageToTargetSize = (img, targetSize) => {
+const resizeImageToTargetSize = (img: HTMLImageElement, targetSize: number): Promise<HTMLCanvasElement> => {
     return new Promise((resolve) => {
         const canvas = document.createElement('canvas');
-        const ctx = canvas.getContext('2d');
+        const ctx = canvas.getContext('2d')!;
         const maxDimension = Math.max(img.width, img.height);
         const minDimension = Math.min(img.width, img.height);
 
@@ -414,8 +414,6 @@ const resizeImageToTargetSize = (img, targetSize) => {
         canvas.height = finalHeight;
 
         ctx.imageSmoothingEnabled = false;
-        ctx.webkitImageSmoothingEnabled = false;
-        ctx.mozImageSmoothingEnabled = false;
         ctx.drawImage(img, 0, 0, finalWidth, finalHeight);
 
         resolve(canvas);
@@ -435,6 +433,7 @@ const downloadResizedImage = async (targetSize: number) => {
             const resizedCanvas = await resizeImageToTargetSize(img, targetSize);
 
             resizedCanvas.toBlob((blob) => {
+                if (!blob) return;
                 const url = URL.createObjectURL(blob);
                 const el = document.createElement('a');
                 el.href = url;

--- a/components/SizeSelectionModal.vue
+++ b/components/SizeSelectionModal.vue
@@ -14,23 +14,16 @@
       </v-card-text>
       <v-card-actions>
         <v-spacer></v-spacer>
-        <v-btn @click="close" variant="outline">Cancel</v-btn>
+        <v-btn @click="close" variant="text">Cancel</v-btn>
       </v-card-actions>
     </v-card>
   </v-dialog>
 </template>
 
 <script setup lang="ts">
-const props = defineProps({
-  modelValue: Boolean
-})
+const show = defineModel<boolean>()
 
-const emit = defineEmits(['update:modelValue', 'select'])
-
-const show = computed({
-  get: () => props.modelValue,
-  set: (value) => emit('update:modelValue', value)
-})
+const emit = defineEmits(['select'])
 
 const sizes = [32, 64, 128, 256, 512, 1024]
 

--- a/components/SizeSelectionModal.vue
+++ b/components/SizeSelectionModal.vue
@@ -1,0 +1,45 @@
+<template>
+  <v-dialog v-model="show" max-width="500px">
+    <v-card>
+        <template #title>Scale Image</template>
+        <template #subtitle>Download the image in an other scale.</template>
+      <v-card-text>
+        <v-row>
+          <v-col v-for="size in sizes" :key="size" cols="4">
+            <v-btn @click="selectSize(size)" block variant="flat" color="primary">
+              {{ size }}px
+            </v-btn>
+          </v-col>
+        </v-row>
+      </v-card-text>
+      <v-card-actions>
+        <v-spacer></v-spacer>
+        <v-btn @click="close" variant="outline">Cancel</v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script setup lang="ts">
+const props = defineProps({
+  modelValue: Boolean
+})
+
+const emit = defineEmits(['update:modelValue', 'select'])
+
+const show = computed({
+  get: () => props.modelValue,
+  set: (value) => emit('update:modelValue', value)
+})
+
+const sizes = [32, 64, 128, 256, 512, 1024]
+
+const selectSize = (size: number) => {
+  emit('select', size)
+  show.value = false
+}
+
+const close = () => {
+  show.value = false
+}
+</script>


### PR DESCRIPTION
# Scale up and down images

Hello :hand: ! 

It is not the first time I tried to download Minecraft textures to change it with higher dimensions. So `Download on mcasset > Open GIMP > Scale Up > Overwrite the older one` was too long for me !

I added a **button to download the image with another scale**. (from 32px to 1024px).
- It keeps images ratios.
- It only appears on `isImage` is true.  
- Users can choose the scale with a modal.
- You can either, upscale or downscale.


## Tests

I only tested with these configurations :
- Firefox 146.0.1 (64-bit) on Pop_OS
- Node 22.14.0
- Tested with `npm run dev` and `npm run build && npm run preview`
- The extensions NoScript was activated (so cookie-script and Google was deactivated). I didn't try without. 

## Images

### The "Other Size" button

#### Desktop 

<img width="1920" height="935" alt="desktop" src="https://github.com/user-attachments/assets/69d39a7a-f843-4c8d-a62e-fba1e6a6efd9" />

#### Mobile

<img width="1125" height="2436" alt="mobile" src="https://github.com/user-attachments/assets/a76ee7b3-edfb-438e-8054-aa6b0058fe4e" />

### The modal

#### Desktop

<img width="1920" height="935" alt="desktop-modal" src="https://github.com/user-attachments/assets/34bccddd-1ad7-4a39-bded-75ebdaa46d38" />

#### Mobile

<img width="1125" height="2436" alt="mobile-modal" src="https://github.com/user-attachments/assets/ca7f1636-432c-47d6-99fa-edda6b949427" /> 
</summary>
</details>


## Fun Fact !

I asked myself **what's the biggest dimensions of a minecraft textures images**. There is the top 50 of the 1.21.11 and without surprise, the biggest dimension is 1024px.

```
~/Downloads/InventivetalentDev-minecraft-assets-1.21.11-0-g7241a12/InventivetalentDev-minecraft-assets-2c88d59$ python main.py -n 50
Top 50 heaviest PNG files (in KB):
----------------------------------------------------------------------
File                                               | Size (KB)  | Dimensions (px)
----------------------------------------------------------------------
1. 9.png                                         | 846.96     | 780x608
2. 14.png                                        | 756.94     | 780x608
3. 6.png                                         | 752.96     | 780x608
4. 10.png                                        | 738.76     | 780x608
5. 2.png                                         | 697.60     | 780x608
6. panorama_1.png                                | 677.58     | 1024x1024
7. 4.png                                         | 655.53     | 780x608
8. 3.png                                         | 648.75     | 780x608
9. 13.png                                        | 631.61     | 780x608
10. 1.png                                         | 618.49     | 780x608
11. panorama_0.png                                | 610.42     | 1024x1024
12. 12.png                                        | 591.26     | 780x608
13. 15.png                                        | 526.20     | 780x608
14. panorama_2.png                                | 498.21     | 1024x1024
15. 7.png                                         | 495.84     | 780x608
16. 8.png                                         | 490.27     | 780x608
17. panorama_3.png                                | 449.78     | 1024x1024
18. 11.png                                        | 448.58     | 780x608
19. panorama_4.png                                | 241.60     | 1024x1024
20. 5.png                                         | 228.26     | 780x608
21. panorama_5.png                                | 196.37     | 1024x1024
22. adventure.png                                 | 121.57     | 256x256
23. upload.png                                    | 113.63     | 256x256
24. experience.png                                | 106.41     | 256x256
25. survival_spawn.png                            | 99.94      | 256x256
26. isles.png                                     | 89.38      | 256x256
27. inspiration.png                               | 67.92      | 256x256
28. new_world.png                                 | 60.26      | 256x256
29. minceraft.png                                 | 40.67      | 1024x256
30. minecraft.png                                 | 33.62      | 1024x256
31. dragon_exploding.png                          | 23.93      | 256x256
32. icon_256x256.png                              | 19.22      | 256x256
33. icon_256x256.png                              | 19.18      | 256x256
34. realms.png                                    | 17.08      | 512x256
35. foliage.png                                   | 13.82      | 256x256
36. nausea.png                                    | 12.63      | 256x256
37. end_sky.png                                   | 12.09      | 128x128
38. enchanted_glint_item.png                      | 12.02      | 128x128
39. unknown_pack.png                              | 11.01      | 128x128
40. edition.png                                   | 10.52      | 512x64
41. mojangstudios.png                             | 9.36       | 512x512
42. pumpkinblur.png                               | 9.25       | 256x256
43. icon_128x128.png                              | 8.89       | 128x128
44. icon_128x128.png                              | 8.87       | 128x128
45. orb.png                                       | 8.82       | 64x64
46. end_portal.png                                | 8.78       | 256x256
47. dry_foliage.png                               | 8.77       | 256x256
48. nether_portal.png                             | 8.74       | 16x512
49. pointer.png                                   | 8.17       | 64x64
50. fire_1.png                                    | 8.15       | 16x512
``` 

 

