### PR TITLE
Added a shortcut to Search Modal

### DIFF
--- a/components/AssetSearchDialog.vue
+++ b/components/AssetSearchDialog.vue
@@ -6,7 +6,7 @@
 }
 </style>
 <template>
-    <v-dialog max-width="800">
+    <v-dialog v-model="dialogOpen" max-width="800">
         <template v-slot:activator="{ props: activatorProps }">
             <v-btn
                 v-bind="activatorProps"
@@ -136,6 +136,25 @@ const miniSearch = computed(() => {
 
 const query = ref<string>('');
 const searchResults = ref<(SearchResult & AssetIndexEntryWithMeta)[]>([]);
+const dialogOpen = ref(false);
+
+const handleKeyDown = (event: KeyboardEvent) => {
+  const isInput = event.target instanceof HTMLInputElement ||
+                 event.target instanceof HTMLTextAreaElement;
+
+  if ((event.ctrlKey || event.metaKey) && event.key === 'k' && !isInput) {
+    event.preventDefault();
+    dialogOpen.value = true;
+  }
+};
+
+onMounted(() => {
+  window.addEventListener('keydown', handleKeyDown);
+});
+
+onUnmounted(() => {
+  window.removeEventListener('keydown', handleKeyDown);
+});
 
 const updateSearch = useDebounceFn(() => {
     // searchResults.value = searchAssets();

--- a/components/AssetSearchDialog.vue
+++ b/components/AssetSearchDialog.vue
@@ -140,12 +140,9 @@ const searchResults = ref<(SearchResult & AssetIndexEntryWithMeta)[]>([]);
 const dialogOpen = ref(false);
 
 const handleKeyDown = (event: KeyboardEvent) => {
-  const isInput = event.target instanceof HTMLInputElement ||
-                 event.target instanceof HTMLTextAreaElement;
-
-  if ((event.ctrlKey || event.metaKey) && event.key === 'k' && !isInput) {
+  if ((event.ctrlKey || event.metaKey) && event.key === 'k') {
     event.preventDefault();
-    dialogOpen.value = true;
+    dialogOpen.value = dialogOpen.value ? false : true;
 
     setTimeout(() => {
       const searchInput = document.querySelector('#search-input');

--- a/components/AssetSearchDialog.vue
+++ b/components/AssetSearchDialog.vue
@@ -34,6 +34,7 @@
                     <v-row dense>
                         <v-col cols="12">
                             <v-text-field
+                                id="search-input"
                                 label="Query"
                                 v-model="query"
                                 @keyup="updateSearch"
@@ -145,6 +146,13 @@ const handleKeyDown = (event: KeyboardEvent) => {
   if ((event.ctrlKey || event.metaKey) && event.key === 'k' && !isInput) {
     event.preventDefault();
     dialogOpen.value = true;
+
+    setTimeout(() => {
+      const searchInput = document.querySelector('#search-input');
+      if (searchInput) {
+        searchInput.focus();
+      }
+    }, 200);
   }
 };
 

--- a/components/AssetSearchDialog.vue
+++ b/components/AssetSearchDialog.vue
@@ -34,7 +34,7 @@
                     <v-row dense>
                         <v-col cols="12">
                             <v-text-field
-                                id="search-input"
+                                ref="searchInput"
                                 label="Query"
                                 v-model="query"
                                 @keyup="updateSearch"
@@ -136,18 +136,18 @@ const miniSearch = computed(() => {
 
 
 const query = ref<string>('');
+const searchInput = ref<HTMLInputElement|null>(null);
 const searchResults = ref<(SearchResult & AssetIndexEntryWithMeta)[]>([]);
 const dialogOpen = ref(false);
 
 const handleKeyDown = (event: KeyboardEvent) => {
   if ((event.ctrlKey || event.metaKey) && event.key === 'k') {
     event.preventDefault();
-    dialogOpen.value = dialogOpen.value ? false : true;
+    dialogOpen.value = !dialogOpen.value;
 
     setTimeout(() => {
-      const searchInput = document.querySelector('#search-input');
-      if (searchInput) {
-        searchInput.focus();
+      if (searchInput.value) {
+        searchInput.value.focus();
       }
     }, 200);
   }


### PR DESCRIPTION
# Shortcut on Search Modal

Hello :hand: again !

After the [scaling feature](https://github.com/InventivetalentDev/mcasset.cloud/pull/88), I wanted to just increase UX with addind shortcut to quicly open the search modal.

We can type on our keyboard a "ctrl + k" to open/close the search modal.
- **Open/Close** with the shortcut.
- **Autofocus on the input** to stay on the keyboard. _(With a timeout to ensure focus)_
- Compatible with the **cmd key on macOS** _(Theoretically. I didn't test. I don't have a Mac)_


## Tests

I only tested with these configurations :

- Firefox 146.0.1 (64-bit) on Pop_OS
- Node 22.14.0
- Tested with `npm run dev` and `npm run build && npm run preview`
- The extensions NoScript was activated (so cookie-script and Google was deactivated). I didn't try without.
