### PR TITLE
Add embedded audio player for audio assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,14 @@ dist
 # Node dependencies
 node_modules
 
+# Yarn
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/sdks
+!.yarn/versions
+
 # Logs
 logs
 *.log

--- a/components/AssetView.vue
+++ b/components/AssetView.vue
@@ -67,13 +67,11 @@ img.zoomed {
                 </div>
                 <div v-else>
                     <v-sheet color="grey-darken-3" class="pa-2 asset-sheet">
-                        <div v-if="contentTooLarge || forceRaw">
+                        <AudioPlayer v-if="isAudio" :src="assetRawUrl"/>
+                        <div v-else-if="contentTooLarge || forceRaw">
                             <a :href="cdnUrl" target="_blank">View Raw</a>
                         </div>
                         <img v-else-if="isImage" :src="assetRawUrl" :alt="assetName" :class="{'zoomed': zoomed}"/>
-                        <audio v-else-if="isAudio" :src="assetRawUrl" controls>
-                            Your browser does not support the audio element.
-                        </audio>
                         <div v-else>
                             <span v-if="contentSizeBytes<=0"><i>Empty File</i></span>
                             <!--                            <BlobAsText :blob="assetContent"/>-->
@@ -100,6 +98,7 @@ import BackBtn from "~/components/BackBtn.vue";
 // import BlobAsText from "~/components/BlobAsText.vue";
 import TextContent from "~/components/TextContent.vue";
 import SizeSelectionModal from "~/components/SizeSelectionModal.vue";
+import AudioPlayer from "~/components/AudioPlayer.vue";
 
 const props = defineProps<{
     version: string,

--- a/components/AudioPlayer.vue
+++ b/components/AudioPlayer.vue
@@ -1,0 +1,112 @@
+<style scoped>
+.audio-player {
+    width: 100%;
+    max-width: 520px;
+}
+
+.time-display {
+    font-variant-numeric: tabular-nums;
+}
+</style>
+<template>
+    <div class="audio-player">
+        <audio ref="audioEl" :src="src" :loop="loop" preload="metadata"/>
+        <v-row align="center" no-gutters>
+            <v-col cols="auto">
+                <v-btn
+                    icon
+                    variant="text"
+                    :color="playing ? 'primary' : undefined"
+                    @click="togglePlay">
+                    <v-icon :icon="playing ? 'mdi-pause' : 'mdi-play'" size="large"/>
+                </v-btn>
+            </v-col>
+            <v-col cols="auto" class="px-2 text-caption text-medium-emphasis text-no-wrap time-display">
+                {{ formatTime(currentTime) }} / {{ formatTime(duration) }}
+            </v-col>
+            <v-col class="px-2">
+                <v-slider
+                    :model-value="currentTime"
+                    :min="0"
+                    :max="duration || 0"
+                    :step="0.05"
+                    color="primary"
+                    density="compact"
+                    hide-details
+                    @update:model-value="onSeek"/>
+            </v-col>
+            <v-col cols="auto">
+                <v-btn
+                    icon
+                    variant="text"
+                    size="small"
+                    @click="toggleMute">
+                    <v-icon :icon="volumeIcon"/>
+                </v-btn>
+            </v-col>
+            <v-col cols="auto" class="pe-2" style="width: 90px">
+                <v-slider
+                    v-model="volume"
+                    :min="0"
+                    :max="1"
+                    :step="0.01"
+                    color="primary"
+                    density="compact"
+                    hide-details/>
+            </v-col>
+            <v-col cols="auto">
+                <v-btn
+                    icon
+                    variant="text"
+                    size="small"
+                    :color="loop ? 'primary' : undefined"
+                    @click="loop = !loop">
+                    <v-icon icon="mdi-repeat"/>
+                </v-btn>
+            </v-col>
+        </v-row>
+    </div>
+</template>
+<script setup lang="ts">
+import { useMediaControls } from "@vueuse/core";
+
+defineProps<{
+    src: string
+}>();
+
+const audioEl = ref<HTMLAudioElement>();
+const loop = ref(false);
+
+const {
+    playing,
+    currentTime,
+    duration,
+    volume,
+    muted,
+} = useMediaControls(audioEl);
+
+const togglePlay = () => {
+    playing.value = !playing.value;
+};
+
+const toggleMute = () => {
+    muted.value = !muted.value;
+};
+
+const onSeek = (value: number) => {
+    currentTime.value = value;
+};
+
+const volumeIcon = computed(() => {
+    if (muted.value || volume.value <= 0) return 'mdi-volume-off';
+    if (volume.value < 0.5) return 'mdi-volume-medium';
+    return 'mdi-volume-high';
+});
+
+const formatTime = (seconds: number) => {
+    if (!seconds || !isFinite(seconds)) return '0:00';
+    const mins = Math.floor(seconds / 60);
+    const secs = Math.floor(seconds % 60);
+    return `${ mins }:${ secs.toString().padStart(2, '0') }`;
+};
+</script>


### PR DESCRIPTION
Replace the bare HTML <audio controls> tag with a dedicated Vuetify-styled AudioPlayer component (play/pause, seek, time, volume, loop) built on @vueuse/core's useMediaControls.

Render the player before the contentTooLarge check so larger .ogg files (music tracks, records like pigstep.ogg at ~4.8MB) get a player instead of falling through to the 'View Raw' link.